### PR TITLE
Unit tests for business layer fix

### DIFF
--- a/src/main/java/bootcamp/five/agency/newys/domain/Article.java
+++ b/src/main/java/bootcamp/five/agency/newys/domain/Article.java
@@ -104,6 +104,10 @@ public class Article {
     return categories;
   }
 
+  public static ArticleBuilder builder() {
+    return new ArticleBuilder();
+  }
+
   public static class ArticleBuilder {
 
     private Long id;

--- a/src/main/java/bootcamp/five/agency/newys/domain/Author.java
+++ b/src/main/java/bootcamp/five/agency/newys/domain/Author.java
@@ -75,6 +75,10 @@ public class Author {
     return categories;
   }
 
+  public static AuthorBuilder builder() {
+    return new AuthorBuilder();
+  }
+
   public static class AuthorBuilder {
 
     private Long id;

--- a/src/main/java/bootcamp/five/agency/newys/domain/Category.java
+++ b/src/main/java/bootcamp/five/agency/newys/domain/Category.java
@@ -80,8 +80,8 @@ public class Category {
     return addedArticles;
   }
 
-  public void setAddedArticles(List<Article> addedArticles) {
-    this.addedArticles = addedArticles;
+  public static CategoryBuilder builder() {
+    return new CategoryBuilder();
   }
 
   public static class CategoryBuilder {

--- a/src/main/java/bootcamp/five/agency/newys/dto/request/author/CreateAuthorRequestDto.java
+++ b/src/main/java/bootcamp/five/agency/newys/dto/request/author/CreateAuthorRequestDto.java
@@ -7,16 +7,6 @@ public class CreateAuthorRequestDto {
   private String email;
   private String type;
 
-  public CreateAuthorRequestDto() {
-  }
-
-  private CreateAuthorRequestDto(String firstName, String lastName, String email, String type) {
-    this.firstName = firstName;
-    this.lastName = lastName;
-    this.email = email;
-    this.type = type;
-  }
-
   public String getFirstName() {
     return firstName;
   }
@@ -33,35 +23,4 @@ public class CreateAuthorRequestDto {
     return type;
   }
 
-  public static class CreateAuthorRequestDtoBuilder {
-
-    private String firstName;
-    private String lastName;
-    private String email;
-    private String type;
-
-    public CreateAuthorRequestDtoBuilder firstName(String firstName) {
-      this.firstName = firstName;
-      return this;
-    }
-
-    public CreateAuthorRequestDtoBuilder lastName(String lastName) {
-      this.lastName = lastName;
-      return this;
-    }
-
-    public CreateAuthorRequestDtoBuilder email(String email) {
-      this.email = email;
-      return this;
-    }
-
-    public CreateAuthorRequestDtoBuilder type(String type) {
-      this.type = type;
-      return this;
-    }
-
-    public CreateAuthorRequestDto build() {
-      return new CreateAuthorRequestDto(firstName, lastName, email, type);
-    }
-  }
 }

--- a/src/main/java/bootcamp/five/agency/newys/dto/request/author/UpdateAuthorRequestDto.java
+++ b/src/main/java/bootcamp/five/agency/newys/dto/request/author/UpdateAuthorRequestDto.java
@@ -7,16 +7,6 @@ public class UpdateAuthorRequestDto {
   private String email;
   private String type;
 
-  public UpdateAuthorRequestDto() {
-  }
-
-  private UpdateAuthorRequestDto(String firstName, String lastName, String email, String type) {
-    this.firstName = firstName;
-    this.lastName = lastName;
-    this.email = email;
-    this.type = type;
-  }
-
   public String getFirstName() {
     return firstName;
   }
@@ -33,35 +23,4 @@ public class UpdateAuthorRequestDto {
     return type;
   }
 
-  public static class UpdateAuthorRequestDtoBuilder {
-
-    private String firstName;
-    private String lastName;
-    private String email;
-    private String type;
-
-    public UpdateAuthorRequestDtoBuilder firstName(String firstName) {
-      this.firstName = firstName;
-      return this;
-    }
-
-    public UpdateAuthorRequestDtoBuilder lastName(String lastName) {
-      this.lastName = lastName;
-      return this;
-    }
-
-    public UpdateAuthorRequestDtoBuilder email(String email) {
-      this.email = email;
-      return this;
-    }
-
-    public UpdateAuthorRequestDtoBuilder type(String type) {
-      this.type = type;
-      return this;
-    }
-
-    public UpdateAuthorRequestDto build() {
-      return new UpdateAuthorRequestDto(firstName, lastName, email, type);
-    }
-  }
 }

--- a/src/main/java/bootcamp/five/agency/newys/dto/response/article/GetArticleDetailsResponseDto.java
+++ b/src/main/java/bootcamp/five/agency/newys/dto/response/article/GetArticleDetailsResponseDto.java
@@ -60,6 +60,10 @@ public class GetArticleDetailsResponseDto {
     return authorId;
   }
 
+  public static GetArticleDetailsResponseDtoBuilder builder() {
+    return new GetArticleDetailsResponseDtoBuilder();
+  }
+
   public static class GetArticleDetailsResponseDtoBuilder {
 
     private Long id;

--- a/src/main/java/bootcamp/five/agency/newys/dto/response/article/GetArticleInCategoryResponseDto.java
+++ b/src/main/java/bootcamp/five/agency/newys/dto/response/article/GetArticleInCategoryResponseDto.java
@@ -39,6 +39,10 @@ public class GetArticleInCategoryResponseDto {
     return categoryName;
   }
 
+  public static GetArticleInCategoryResponseDtoBuilder builder() {
+    return new GetArticleInCategoryResponseDtoBuilder();
+  }
+
   public static class GetArticleInCategoryResponseDtoBuilder {
 
     private Long id;

--- a/src/main/java/bootcamp/five/agency/newys/dto/response/article/GetAuthorArticlesResponseDto.java
+++ b/src/main/java/bootcamp/five/agency/newys/dto/response/article/GetAuthorArticlesResponseDto.java
@@ -45,6 +45,10 @@ public class GetAuthorArticlesResponseDto {
     return authorLastName;
   }
 
+  public static GetAuthorArticlesResponseDtoBuilder builder() {
+    return new GetAuthorArticlesResponseDtoBuilder();
+  }
+
   public static class GetAuthorArticlesResponseDtoBuilder {
 
     private Long id;

--- a/src/main/java/bootcamp/five/agency/newys/dto/response/article/GetLatestArticlesResponseDto.java
+++ b/src/main/java/bootcamp/five/agency/newys/dto/response/article/GetLatestArticlesResponseDto.java
@@ -35,6 +35,10 @@ public class GetLatestArticlesResponseDto {
     return dateOfPublication;
   }
 
+  public static GetLatestArticlesResponseDtoBuilder builder() {
+    return new GetLatestArticlesResponseDtoBuilder();
+  }
+
   public static class GetLatestArticlesResponseDtoBuilder {
 
     private Long id;

--- a/src/main/java/bootcamp/five/agency/newys/dto/response/article/GetPopularArticlesResponseDto.java
+++ b/src/main/java/bootcamp/five/agency/newys/dto/response/article/GetPopularArticlesResponseDto.java
@@ -33,6 +33,10 @@ public class GetPopularArticlesResponseDto {
     return numLikes;
   }
 
+  public static GetPopularArticlesResponseDtoBuilder builder() {
+    return new GetPopularArticlesResponseDtoBuilder();
+  }
+
   public static class GetPopularArticlesResponseDtoBuilder {
 
     private Long id;

--- a/src/main/java/bootcamp/five/agency/newys/dto/response/author/AuthorDetailsResponseDto.java
+++ b/src/main/java/bootcamp/five/agency/newys/dto/response/author/AuthorDetailsResponseDto.java
@@ -39,6 +39,10 @@ public class AuthorDetailsResponseDto {
     return type;
   }
 
+  public static GetAuthorDetailsResponseDtoBuilder builder() {
+    return new GetAuthorDetailsResponseDtoBuilder();
+  }
+
   public static class GetAuthorDetailsResponseDtoBuilder {
 
     private Long id;

--- a/src/main/java/bootcamp/five/agency/newys/dto/response/category/GetAuthorCategoriesResponseDto.java
+++ b/src/main/java/bootcamp/five/agency/newys/dto/response/category/GetAuthorCategoriesResponseDto.java
@@ -45,6 +45,10 @@ public class GetAuthorCategoriesResponseDto {
     return authorLastName;
   }
 
+  public static GetAuthorCategoriesResponseDtoBuilder builder() {
+    return new GetAuthorCategoriesResponseDtoBuilder();
+  }
+
   public static class GetAuthorCategoriesResponseDtoBuilder {
 
     private Long id;

--- a/src/main/java/bootcamp/five/agency/newys/dto/response/category/GetCategoryDetailsResponseDto.java
+++ b/src/main/java/bootcamp/five/agency/newys/dto/response/category/GetCategoryDetailsResponseDto.java
@@ -33,6 +33,10 @@ public class GetCategoryDetailsResponseDto {
     return authorId;
   }
 
+  public static GetCategoryDetailsResponseDtoBuilder builder() {
+    return new GetCategoryDetailsResponseDtoBuilder();
+  }
+
   public static class GetCategoryDetailsResponseDtoBuilder {
 
     private Long id;

--- a/src/main/java/bootcamp/five/agency/newys/mappers/ArticleMapper.java
+++ b/src/main/java/bootcamp/five/agency/newys/mappers/ArticleMapper.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 public class ArticleMapper {
 
   public GetArticleDetailsResponseDto convertToGetArticleDetailsResponseDto(Article article) {
-    return new GetArticleDetailsResponseDto.GetArticleDetailsResponseDtoBuilder()
+    return GetArticleDetailsResponseDto.builder()
         .id(article.getId())
         .title(article.getTitle())
         .description(article.getDescription())
@@ -27,7 +27,7 @@ public class ArticleMapper {
   }
 
   public GetAuthorArticlesResponseDto convertToGetAuthorArticlesResponseDto(Article article, Author author) {
-    return new GetAuthorArticlesResponseDto.GetAuthorArticlesResponseDtoBuilder()
+    return GetAuthorArticlesResponseDto.builder()
         .id(article.getId())
         .title(article.getTitle())
         .description(article.getDescription())
@@ -38,7 +38,7 @@ public class ArticleMapper {
   }
 
   public GetLatestArticlesResponseDto convertToGetLatestArticlesResponseDto(Article article) {
-    return new GetLatestArticlesResponseDto.GetLatestArticlesResponseDtoBuilder()
+    return GetLatestArticlesResponseDto.builder()
         .id(article.getId())
         .title(article.getTitle())
         .description(article.getDescription())
@@ -47,7 +47,7 @@ public class ArticleMapper {
   }
 
   public GetPopularArticlesResponseDto convertToGetPopularArticlesResponseDto(Article article) {
-    return new GetPopularArticlesResponseDto.GetPopularArticlesResponseDtoBuilder()
+    return GetPopularArticlesResponseDto.builder()
         .id(article.getId())
         .title(article.getTitle())
         .description(article.getDescription())
@@ -56,7 +56,7 @@ public class ArticleMapper {
   }
 
   public GetArticleInCategoryResponseDto convertToGetArticleInCategoryResponseDto(Article article, Category category) {
-    return new GetArticleInCategoryResponseDto.GetArticleInCategoryResponseDtoBuilder()
+    return GetArticleInCategoryResponseDto.builder()
         .id(article.getId())
         .title(article.getTitle())
         .description(article.getDescription())

--- a/src/main/java/bootcamp/five/agency/newys/mappers/AuthorMapper.java
+++ b/src/main/java/bootcamp/five/agency/newys/mappers/AuthorMapper.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 public class AuthorMapper {
 
   public AuthorDetailsResponseDto convertToGetAuthorDetailsResponseDto(Author author) {
-    return new AuthorDetailsResponseDto.GetAuthorDetailsResponseDtoBuilder()
+    return AuthorDetailsResponseDto.builder()
         .id(author.getId())
         .firstName(author.getFirstName())
         .lastName(author.getLastName())

--- a/src/main/java/bootcamp/five/agency/newys/mappers/CategoryMapper.java
+++ b/src/main/java/bootcamp/five/agency/newys/mappers/CategoryMapper.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 public class CategoryMapper {
 
   public GetCategoryDetailsResponseDto convertToGetCategoryDetailsResponseDto(Category category) {
-    return new GetCategoryDetailsResponseDto.GetCategoryDetailsResponseDtoBuilder()
+    return GetCategoryDetailsResponseDto.builder()
         .id(category.getId())
         .name(category.getName())
         .description(category.getDescription())
@@ -19,7 +19,7 @@ public class CategoryMapper {
   }
 
   public GetAuthorCategoriesResponseDto convertToGetCategoryDetailsResponseDto(Category category, Author author) {
-    return new GetAuthorCategoriesResponseDto.GetAuthorCategoriesResponseDtoBuilder()
+    return GetAuthorCategoriesResponseDto.builder()
         .id(category.getId())
         .name(category.getName())
         .description(category.getDescription())

--- a/src/main/java/bootcamp/five/agency/newys/services/article/CreateArticleService.java
+++ b/src/main/java/bootcamp/five/agency/newys/services/article/CreateArticleService.java
@@ -6,7 +6,7 @@ import bootcamp.five.agency.newys.dto.response.article.GetArticleDetailsResponse
 import bootcamp.five.agency.newys.mappers.ArticleMapper;
 import bootcamp.five.agency.newys.repository.ArticleRepository;
 import bootcamp.five.agency.newys.repository.AuthorRepository;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -29,7 +29,7 @@ public class CreateArticleService {
     Author author = authorRepository.findById(authorId)
         .orElseThrow(() -> new IllegalStateException("Author does not exists"));
 
-    return articleMapper.convertToGetArticleDetailsResponseDto(articleRepository.save(new Article.ArticleBuilder()
+    return articleMapper.convertToGetArticleDetailsResponseDto(articleRepository.save(Article.builder()
         .title(title)
         .description(description)
         .imageUrl(imageUrl)
@@ -37,7 +37,7 @@ public class CreateArticleService {
         .content(content)
         .numLikes(0)
         .author(author)
-        .categories(new ArrayList<>())
+        .categories(Collections.emptyList())
         .build()));
   }
 

--- a/src/main/java/bootcamp/five/agency/newys/services/article/GetArticleService.java
+++ b/src/main/java/bootcamp/five/agency/newys/services/article/GetArticleService.java
@@ -10,7 +10,7 @@ import bootcamp.five.agency.newys.repository.ArticleRepository;
 import bootcamp.five.agency.newys.repository.AuthorRepository;
 import java.sql.Date;
 import java.time.LocalDate;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -43,25 +43,25 @@ public class GetArticleService {
     return Optional.of(articleRepository.findByAuthor(author))
         .map(articles -> articles.stream().map(article ->
             articleMapper.convertToGetAuthorArticlesResponseDto(article, author)).collect(Collectors.toList()))
-        .orElse(new ArrayList<>());
+        .orElse(Collections.emptyList());
   }
 
   public List<GetLatestArticlesResponseDto> getLatestArticles() {
     return Optional.ofNullable(articleRepository.findByDateOfPublicationAfter(Date.valueOf(LocalDate.now().minusDays(7))))
         .map(entities -> entities.stream().map(articleMapper::convertToGetLatestArticlesResponseDto).collect(Collectors.toList()))
-        .orElse(new ArrayList<>());
+        .orElse(Collections.emptyList());
   }
 
   public List<GetPopularArticlesResponseDto> getPopularArticles() {
     return Optional.ofNullable(articleRepository.findByNumLikesGreaterThan(3))
         .map(entities -> entities.stream().map(articleMapper::convertToGetPopularArticlesResponseDto).collect(Collectors.toList()))
-        .orElse(new ArrayList<>());
+        .orElse(Collections.emptyList());
   }
 
   public List<GetArticleDetailsResponseDto> getAll() {
     return Optional.of(articleRepository.findAll())
         .map(entities -> entities.stream().map(articleMapper::convertToGetArticleDetailsResponseDto).collect(Collectors.toList()))
-        .orElse(new ArrayList<>());
+        .orElse(Collections.emptyList());
   }
 
 }

--- a/src/main/java/bootcamp/five/agency/newys/services/article/UpdateArticleService.java
+++ b/src/main/java/bootcamp/five/agency/newys/services/article/UpdateArticleService.java
@@ -27,7 +27,7 @@ public class UpdateArticleService {
     Article article = articleRepository.findById(id)
         .orElseThrow(() -> new IllegalStateException("Article does not exists"));
 
-    return articleMapper.convertToGetArticleDetailsResponseDto(articleRepository.save(new Article.ArticleBuilder()
+    return articleMapper.convertToGetArticleDetailsResponseDto(articleRepository.save(Article.builder()
         .id(article.getId())
         .title(title)
         .description(description)

--- a/src/main/java/bootcamp/five/agency/newys/services/author/CreateAuthorService.java
+++ b/src/main/java/bootcamp/five/agency/newys/services/author/CreateAuthorService.java
@@ -4,7 +4,7 @@ import bootcamp.five.agency.newys.domain.Author;
 import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
 import bootcamp.five.agency.newys.mappers.AuthorMapper;
 import bootcamp.five.agency.newys.repository.AuthorRepository;
-import java.util.ArrayList;
+import java.util.Collections;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -22,13 +22,13 @@ public class CreateAuthorService {
   }
 
   public AuthorDetailsResponseDto createAuthor(String firstName, String lastName, String email, String type) {
-    return authorMapper.convertToGetAuthorDetailsResponseDto(authorRepository.save(new Author.AuthorBuilder()
+    return authorMapper.convertToGetAuthorDetailsResponseDto(authorRepository.save(Author.builder()
         .firstName(firstName)
         .lastName(lastName)
         .email(email)
         .type(type)
-        .articles(new ArrayList<>())
-        .categories(new ArrayList<>())
+        .articles(Collections.emptyList())
+        .categories(Collections.emptyList())
         .build()));
   }
 

--- a/src/main/java/bootcamp/five/agency/newys/services/author/GetAuthorService.java
+++ b/src/main/java/bootcamp/five/agency/newys/services/author/GetAuthorService.java
@@ -4,7 +4,7 @@ import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
 import bootcamp.five.agency.newys.exceptions.AuthorNotFoundException;
 import bootcamp.five.agency.newys.mappers.AuthorMapper;
 import bootcamp.five.agency.newys.repository.AuthorRepository;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -45,13 +45,13 @@ public class GetAuthorService {
   public List<AuthorDetailsResponseDto> getByType(String type) {
     return Optional.ofNullable(authorRepository.findByType(type))
         .map(entities -> entities.stream().map(authorMapper::convertToGetAuthorDetailsResponseDto).collect(Collectors.toList()))
-        .orElse(new ArrayList<>());
+        .orElse(Collections.emptyList());
   }
 
   public List<AuthorDetailsResponseDto> getAll() {
     return Optional.of(authorRepository.findAll())
         .map(entities -> entities.stream().map(authorMapper::convertToGetAuthorDetailsResponseDto).collect(Collectors.toList()))
-        .orElse(new ArrayList<>());
+        .orElse(Collections.emptyList());
   }
 
 }

--- a/src/main/java/bootcamp/five/agency/newys/services/author/UpdateAuthorService.java
+++ b/src/main/java/bootcamp/five/agency/newys/services/author/UpdateAuthorService.java
@@ -23,7 +23,7 @@ public class UpdateAuthorService {
     Author author = authorRepository.findById(id)
         .orElseThrow(() -> new IllegalStateException("Author does not exists"));
 
-    return authorMapper.convertToGetAuthorDetailsResponseDto(authorRepository.save(new Author.AuthorBuilder()
+    return authorMapper.convertToGetAuthorDetailsResponseDto(authorRepository.save(Author.builder()
         .id(author.getId())
         .firstName(firstName)
         .lastName(lastName)

--- a/src/main/java/bootcamp/five/agency/newys/services/category/CreateCategoryService.java
+++ b/src/main/java/bootcamp/five/agency/newys/services/category/CreateCategoryService.java
@@ -6,7 +6,7 @@ import bootcamp.five.agency.newys.dto.response.category.GetCategoryDetailsRespon
 import bootcamp.five.agency.newys.mappers.CategoryMapper;
 import bootcamp.five.agency.newys.repository.AuthorRepository;
 import bootcamp.five.agency.newys.repository.CategoryRepository;
-import java.util.ArrayList;
+import java.util.Collections;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -28,11 +28,11 @@ public class CreateCategoryService {
     Author author = authorRepository.findById(authorId)
         .orElseThrow(() -> new IllegalStateException("Author does not exists"));
 
-    return categoryMapper.convertToGetCategoryDetailsResponseDto(categoryRepository.save(new Category.CategoryBuilder()
+    return categoryMapper.convertToGetCategoryDetailsResponseDto(categoryRepository.save(Category.builder()
         .name(name)
         .description(description)
         .author(author)
-        .addedArticles(new ArrayList<>())
+        .addedArticles(Collections.emptyList())
         .build()));
   }
 

--- a/src/main/java/bootcamp/five/agency/newys/services/category/GetAddedArticlesService.java
+++ b/src/main/java/bootcamp/five/agency/newys/services/category/GetAddedArticlesService.java
@@ -4,7 +4,7 @@ import bootcamp.five.agency.newys.domain.Category;
 import bootcamp.five.agency.newys.dto.response.article.GetArticleInCategoryResponseDto;
 import bootcamp.five.agency.newys.mappers.ArticleMapper;
 import bootcamp.five.agency.newys.repository.CategoryRepository;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -28,7 +28,7 @@ public class GetAddedArticlesService {
     return Optional.of(category.getAddedArticles())
         .map(articles -> articles.stream().map(article ->
             articleMapper.convertToGetArticleInCategoryResponseDto(article, category)).collect(Collectors.toList()))
-        .orElse(new ArrayList<>());
+        .orElse(Collections.emptyList());
   }
 
 }

--- a/src/main/java/bootcamp/five/agency/newys/services/category/GetCategoryService.java
+++ b/src/main/java/bootcamp/five/agency/newys/services/category/GetCategoryService.java
@@ -6,7 +6,7 @@ import bootcamp.five.agency.newys.dto.response.category.GetCategoryDetailsRespon
 import bootcamp.five.agency.newys.mappers.CategoryMapper;
 import bootcamp.five.agency.newys.repository.AuthorRepository;
 import bootcamp.five.agency.newys.repository.CategoryRepository;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -39,13 +39,13 @@ public class GetCategoryService {
     return Optional.of(categoryRepository.findByAuthor(author))
         .map(categories -> categories.stream().map(category ->
             categoryMapper.convertToGetCategoryDetailsResponseDto(category, author)).collect(Collectors.toList()))
-        .orElse(new ArrayList<>());
+        .orElse(Collections.emptyList());
   }
 
   public List<GetCategoryDetailsResponseDto> getAll() {
     return Optional.of(categoryRepository.findAll())
         .map(entities -> entities.stream().map(categoryMapper::convertToGetCategoryDetailsResponseDto).collect(Collectors.toList()))
-        .orElse(new ArrayList<>());
+        .orElse(Collections.emptyList());
   }
 
 }

--- a/src/main/java/bootcamp/five/agency/newys/services/category/UpdateCategoryService.java
+++ b/src/main/java/bootcamp/five/agency/newys/services/category/UpdateCategoryService.java
@@ -62,6 +62,8 @@ public class UpdateCategoryService {
     articleRepository.save(article);
 
     category.getAddedArticles().add(article);
+
+    categoryRepository.save(category);
   }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,9 @@
 server.servlet.context-path=/newys
 
 spring.datasource.url=jdbc:h2:mem:localdb
-#spring.datasource.url= jdbc:h2:file:/Users/vlatko/Workspace/bootcamp/java-bootcamp-demo/src/main/resources/data/demo;AUTO_SERVER=true
-spring.datasource.username=username
-spring.datasource.password=password
+#spring.datasource.url=${DATASOURCE_URL}
+spring.datasource.username=${DATASOURCE_USERNAME}
+spring.datasource.password=${DATASOURCE_PASSWORD}
 spring.datasource.driver-class-name=org.h2.Driver
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/test/java/bootcamp/five/agency/newys/integration/services/article/CreateArticleServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/integration/services/article/CreateArticleServiceTest.java
@@ -1,10 +1,11 @@
-package bootcamp.five.agency.newys.services.article;
+package bootcamp.five.agency.newys.integration.services.article;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import bootcamp.five.agency.newys.dto.response.article.GetArticleDetailsResponseDto;
 import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
+import bootcamp.five.agency.newys.services.article.CreateArticleService;
 import bootcamp.five.agency.newys.services.author.CreateAuthorService;
 import bootcamp.five.agency.newys.services.author.GetAuthorService;
 import java.util.Date;

--- a/src/test/java/bootcamp/five/agency/newys/integration/services/article/DeleteArticleServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/integration/services/article/DeleteArticleServiceTest.java
@@ -1,9 +1,12 @@
-package bootcamp.five.agency.newys.services.article;
+package bootcamp.five.agency.newys.integration.services.article;
 
 import static org.assertj.core.api.Assertions.assertThatException;
 
 import bootcamp.five.agency.newys.dto.response.article.GetAuthorArticlesResponseDto;
 import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
+import bootcamp.five.agency.newys.services.article.CreateArticleService;
+import bootcamp.five.agency.newys.services.article.DeleteArticleService;
+import bootcamp.five.agency.newys.services.article.GetArticleService;
 import bootcamp.five.agency.newys.services.author.CreateAuthorService;
 import bootcamp.five.agency.newys.services.author.GetAuthorService;
 import java.util.Date;

--- a/src/test/java/bootcamp/five/agency/newys/integration/services/article/GetArticleServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/integration/services/article/GetArticleServiceTest.java
@@ -1,4 +1,4 @@
-package bootcamp.five.agency.newys.services.article;
+package bootcamp.five.agency.newys.integration.services.article;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -9,6 +9,9 @@ import bootcamp.five.agency.newys.dto.response.article.GetAuthorArticlesResponse
 import bootcamp.five.agency.newys.dto.response.article.GetLatestArticlesResponseDto;
 import bootcamp.five.agency.newys.dto.response.article.GetPopularArticlesResponseDto;
 import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
+import bootcamp.five.agency.newys.services.article.CreateArticleService;
+import bootcamp.five.agency.newys.services.article.GetArticleService;
+import bootcamp.five.agency.newys.services.article.UpdateArticleService;
 import bootcamp.five.agency.newys.services.author.CreateAuthorService;
 import bootcamp.five.agency.newys.services.author.GetAuthorService;
 import java.util.Date;

--- a/src/test/java/bootcamp/five/agency/newys/integration/services/article/UpdateArticleServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/integration/services/article/UpdateArticleServiceTest.java
@@ -1,4 +1,4 @@
-package bootcamp.five.agency.newys.services.article;
+package bootcamp.five.agency.newys.integration.services.article;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -6,6 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import bootcamp.five.agency.newys.dto.response.article.GetArticleDetailsResponseDto;
 import bootcamp.five.agency.newys.dto.response.article.GetAuthorArticlesResponseDto;
 import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
+import bootcamp.five.agency.newys.services.article.CreateArticleService;
+import bootcamp.five.agency.newys.services.article.GetArticleService;
+import bootcamp.five.agency.newys.services.article.UpdateArticleService;
 import bootcamp.five.agency.newys.services.author.CreateAuthorService;
 import bootcamp.five.agency.newys.services.author.GetAuthorService;
 import java.util.Date;

--- a/src/test/java/bootcamp/five/agency/newys/integration/services/author/CreateAuthorServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/integration/services/author/CreateAuthorServiceTest.java
@@ -1,9 +1,10 @@
-package bootcamp.five.agency.newys.services.author;
+package bootcamp.five.agency.newys.integration.services.author;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
+import bootcamp.five.agency.newys.services.author.CreateAuthorService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/bootcamp/five/agency/newys/integration/services/author/DeleteAuthorServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/integration/services/author/DeleteAuthorServiceTest.java
@@ -1,8 +1,11 @@
-package bootcamp.five.agency.newys.services.author;
+package bootcamp.five.agency.newys.integration.services.author;
 
 import static org.assertj.core.api.Assertions.assertThatException;
 
 import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
+import bootcamp.five.agency.newys.services.author.CreateAuthorService;
+import bootcamp.five.agency.newys.services.author.DeleteAuthorService;
+import bootcamp.five.agency.newys.services.author.GetAuthorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/bootcamp/five/agency/newys/integration/services/author/GetAuthorServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/integration/services/author/GetAuthorServiceTest.java
@@ -1,10 +1,12 @@
-package bootcamp.five.agency.newys.services.author;
+package bootcamp.five.agency.newys.integration.services.author;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
+import bootcamp.five.agency.newys.services.author.CreateAuthorService;
+import bootcamp.five.agency.newys.services.author.GetAuthorService;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/bootcamp/five/agency/newys/integration/services/author/UpdateAuthorServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/integration/services/author/UpdateAuthorServiceTest.java
@@ -1,8 +1,11 @@
-package bootcamp.five.agency.newys.services.author;
+package bootcamp.five.agency.newys.integration.services.author;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
+import bootcamp.five.agency.newys.services.author.CreateAuthorService;
+import bootcamp.five.agency.newys.services.author.GetAuthorService;
+import bootcamp.five.agency.newys.services.author.UpdateAuthorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/bootcamp/five/agency/newys/integration/services/category/CreateCategoryServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/integration/services/category/CreateCategoryServiceTest.java
@@ -1,4 +1,4 @@
-package bootcamp.five.agency.newys.services.category;
+package bootcamp.five.agency.newys.integration.services.category;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -7,6 +7,7 @@ import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
 import bootcamp.five.agency.newys.dto.response.category.GetCategoryDetailsResponseDto;
 import bootcamp.five.agency.newys.services.author.CreateAuthorService;
 import bootcamp.five.agency.newys.services.author.GetAuthorService;
+import bootcamp.five.agency.newys.services.category.CreateCategoryService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/bootcamp/five/agency/newys/integration/services/category/DeleteCategoryServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/integration/services/category/DeleteCategoryServiceTest.java
@@ -1,4 +1,4 @@
-package bootcamp.five.agency.newys.services.category;
+package bootcamp.five.agency.newys.integration.services.category;
 
 import static org.assertj.core.api.Assertions.assertThatException;
 
@@ -6,6 +6,9 @@ import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
 import bootcamp.five.agency.newys.dto.response.category.GetAuthorCategoriesResponseDto;
 import bootcamp.five.agency.newys.services.author.CreateAuthorService;
 import bootcamp.five.agency.newys.services.author.GetAuthorService;
+import bootcamp.five.agency.newys.services.category.CreateCategoryService;
+import bootcamp.five.agency.newys.services.category.DeleteCategoryService;
+import bootcamp.five.agency.newys.services.category.GetCategoryService;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/bootcamp/five/agency/newys/integration/services/category/GetCategoryServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/integration/services/category/GetCategoryServiceTest.java
@@ -1,4 +1,4 @@
-package bootcamp.five.agency.newys.services.category;
+package bootcamp.five.agency.newys.integration.services.category;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -9,6 +9,8 @@ import bootcamp.five.agency.newys.dto.response.category.GetAuthorCategoriesRespo
 import bootcamp.five.agency.newys.dto.response.category.GetCategoryDetailsResponseDto;
 import bootcamp.five.agency.newys.services.author.CreateAuthorService;
 import bootcamp.five.agency.newys.services.author.GetAuthorService;
+import bootcamp.five.agency.newys.services.category.CreateCategoryService;
+import bootcamp.five.agency.newys.services.category.GetCategoryService;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/bootcamp/five/agency/newys/integration/services/category/UpdateCategoryServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/integration/services/category/UpdateCategoryServiceTest.java
@@ -1,4 +1,4 @@
-package bootcamp.five.agency.newys.services.category;
+package bootcamp.five.agency.newys.integration.services.category;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -11,6 +11,10 @@ import bootcamp.five.agency.newys.dto.response.category.GetCategoryDetailsRespon
 import bootcamp.five.agency.newys.services.article.CreateArticleService;
 import bootcamp.five.agency.newys.services.author.CreateAuthorService;
 import bootcamp.five.agency.newys.services.author.GetAuthorService;
+import bootcamp.five.agency.newys.services.category.CreateCategoryService;
+import bootcamp.five.agency.newys.services.category.GetAddedArticlesService;
+import bootcamp.five.agency.newys.services.category.GetCategoryService;
+import bootcamp.five.agency.newys.services.category.UpdateCategoryService;
 import java.util.Date;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;

--- a/src/test/java/bootcamp/five/agency/newys/services/article/CreateArticleServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/services/article/CreateArticleServiceTest.java
@@ -1,18 +1,39 @@
 package bootcamp.five.agency.newys.services.article;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import bootcamp.five.agency.newys.dto.response.article.GetArticleDetailsResponseDto;
+import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
+import bootcamp.five.agency.newys.services.author.CreateAuthorService;
+import bootcamp.five.agency.newys.services.author.GetAuthorService;
 import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CreateArticleServiceTest {
 
   @Autowired
+  private CreateAuthorService createAuthorService;
+  @Autowired
+  private GetAuthorService getAuthorService;
+  @Autowired
   private CreateArticleService createArticleService;
+
+  @BeforeEach
+  public void init() {
+    final String firstName = "Rocky";
+    final String lastName = "Balboa";
+    final String email = "rocky.balboa2@mail.com";
+    final String type = "sport";
+
+    createAuthorService.createAuthor(firstName, lastName, email, type);
+  }
 
   @Test
   public void createArticle_ArticleCreated_True() {
@@ -21,17 +42,19 @@ public class CreateArticleServiceTest {
     final String imageUrl = "images/iphone.png";
     final Date dateOfPublication = new Date();
     final String content = "New iPhone announced";
-    final Long authorId = 1L;
 
-    GetArticleDetailsResponseDto getArticleDetailsResponseDto = createArticleService.createArticle(title, description, imageUrl, dateOfPublication, content, authorId);
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa2@mail.com");
 
-    assertThat(getArticleDetailsResponseDto.getId() != null);
-    assertThat(getArticleDetailsResponseDto.getTitle().equals(title));
-    assertThat(getArticleDetailsResponseDto.getDescription().equals(description));
-    assertThat(getArticleDetailsResponseDto.getImageUrl().equals(imageUrl));
-    assertThat(getArticleDetailsResponseDto.getDateOfPublication().equals(dateOfPublication));
-    assertThat(getArticleDetailsResponseDto.getContent().equals(content));
-    assertThat(getArticleDetailsResponseDto.getAuthorId().equals(authorId));
+    GetArticleDetailsResponseDto getArticleDetailsResponseDto = createArticleService.createArticle(title, description, imageUrl, dateOfPublication,
+        content, authorDetailsResponseDto.getId());
+
+    assertNotNull(getArticleDetailsResponseDto.getId());
+    assertEquals(getArticleDetailsResponseDto.getTitle(), title);
+    assertEquals(getArticleDetailsResponseDto.getDescription(), description);
+    assertEquals(getArticleDetailsResponseDto.getImageUrl(), imageUrl);
+    assertEquals(getArticleDetailsResponseDto.getDateOfPublication(), dateOfPublication);
+    assertEquals(getArticleDetailsResponseDto.getContent(), content);
+    assertEquals(getArticleDetailsResponseDto.getAuthorId(), authorDetailsResponseDto.getId());
   }
 
 }

--- a/src/test/java/bootcamp/five/agency/newys/services/article/DeleteArticleServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/services/article/DeleteArticleServiceTest.java
@@ -1,7 +1,14 @@
 package bootcamp.five.agency.newys.services.article;
 
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatException;
 
+import bootcamp.five.agency.newys.dto.response.article.GetAuthorArticlesResponseDto;
+import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
+import bootcamp.five.agency.newys.services.author.CreateAuthorService;
+import bootcamp.five.agency.newys.services.author.GetAuthorService;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -10,17 +17,48 @@ import org.springframework.boot.test.context.SpringBootTest;
 public class DeleteArticleServiceTest {
 
   @Autowired
+  private CreateAuthorService createAuthorService;
+  @Autowired
+  private GetAuthorService getAuthorService;
+  @Autowired
+  private CreateArticleService createArticleService;
+  @Autowired
   private DeleteArticleService deleteArticleService;
   @Autowired
   private GetArticleService getArticleService;
 
+  @BeforeEach
+  public void init() {
+    final String firstName = "Rocky";
+    final String lastName = "Balboa";
+    final String email = "rocky.balboa8@mail.com";
+    final String type = "sport";
+
+    AuthorDetailsResponseDto authorDetailsResponseDto = createAuthorService.createAuthor(firstName, lastName, email, type);
+
+    final String title = "New iPhone announced";
+    final String description = "New iPhone announced";
+    final String imageUrl = "images/iphone.png";
+    final Date dateOfPublication = new Date();
+    final String content = "New iPhone announced";
+
+    createArticleService.createArticle(title, description, imageUrl, dateOfPublication, content, authorDetailsResponseDto.getId());
+  }
+
   @Test
   public void deleteArticleById_ArticleDeleted_True() {
-    final Long id = 1L;
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa8@mail.com");
 
-    deleteArticleService.deleteArticleById(id);
+    List<GetAuthorArticlesResponseDto> getAuthorArticlesResponseDtoList = getArticleService.getArticlesByAuthor(authorDetailsResponseDto.getId());
 
-    assertThatIllegalStateException().isThrownBy(() -> getArticleService.getArticleById(id));
+    GetAuthorArticlesResponseDto getAuthorArticlesResponseDto = getAuthorArticlesResponseDtoList.stream()
+        .filter(response -> response.getTitle().equals("New iPhone announced"))
+        .findAny()
+        .orElseThrow(() -> new IllegalStateException("Author article does not exists"));
+
+    deleteArticleService.deleteArticleById(getAuthorArticlesResponseDto.getId());
+
+    assertThatException().isThrownBy(() -> getArticleService.getArticleById(getAuthorArticlesResponseDto.getId()));
   }
 
 }

--- a/src/test/java/bootcamp/five/agency/newys/services/article/GetArticleServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/services/article/GetArticleServiceTest.java
@@ -1,60 +1,115 @@
 package bootcamp.five.agency.newys.services.article;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bootcamp.five.agency.newys.dto.response.article.GetArticleDetailsResponseDto;
 import bootcamp.five.agency.newys.dto.response.article.GetAuthorArticlesResponseDto;
 import bootcamp.five.agency.newys.dto.response.article.GetLatestArticlesResponseDto;
 import bootcamp.five.agency.newys.dto.response.article.GetPopularArticlesResponseDto;
+import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
+import bootcamp.five.agency.newys.services.author.CreateAuthorService;
+import bootcamp.five.agency.newys.services.author.GetAuthorService;
+import java.util.Date;
 import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class GetArticleServiceTest {
 
   @Autowired
+  private CreateAuthorService createAuthorService;
+  @Autowired
+  private GetAuthorService getAuthorService;
+  @Autowired
+  private CreateArticleService createArticleService;
+  @Autowired
+  private UpdateArticleService updateArticleService;
+  @Autowired
   private GetArticleService getArticleService;
+
+  @BeforeAll
+  public void initAuthor() {
+    final String firstName = "Rocky";
+    final String lastName = "Balboa";
+    final String email = "rocky.balboa10@mail.com";
+    final String type = "sport";
+
+    AuthorDetailsResponseDto authorDetailsResponseDto = createAuthorService.createAuthor(firstName, lastName, email, type);
+
+    final String title = "New iPhone announced";
+    final String description = "New iPhone announced";
+    final String imageUrl = "images/iphone.png";
+    final Date dateOfPublication = new Date();
+    final String content = "New iPhone announced";
+
+    createArticleService.createArticle(title, description, imageUrl, dateOfPublication, content, authorDetailsResponseDto.getId());
+  }
 
   @Test
   public void getArticleById_ArticleFetched_True() {
-    final Long id = 1L;
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa10@mail.com");
 
-    GetArticleDetailsResponseDto getArticleDetailsResponseDto = getArticleService.getArticleById(id);
+    List<GetAuthorArticlesResponseDto> getAuthorArticlesResponseDtoList = getArticleService.getArticlesByAuthor(authorDetailsResponseDto.getId());
 
-    assertThat(getArticleDetailsResponseDto.getId().equals(id));
+    GetAuthorArticlesResponseDto getAuthorArticlesResponseDto = getAuthorArticlesResponseDtoList.stream()
+        .filter(response -> response.getTitle().equals("New iPhone announced"))
+        .findAny()
+        .orElseThrow(() -> new IllegalStateException("Author article does not exists"));
+
+    GetArticleDetailsResponseDto getArticleDetailsResponseDto = getArticleService.getArticleById(getAuthorArticlesResponseDto.getId());
+
+    assertEquals(getArticleDetailsResponseDto.getId(), getAuthorArticlesResponseDto.getId());
   }
 
   @Test
   public void getArticlesByAuthor_AuthorArticlesFetched_True() {
-    final Long authorId = 1L;
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa10@mail.com");
 
-    List<GetAuthorArticlesResponseDto> getAuthorArticlesResponseDtoList = getArticleService.getArticlesByAuthor(authorId);
+    List<GetAuthorArticlesResponseDto> getAuthorArticlesResponseDtoList = getArticleService.getArticlesByAuthor(authorDetailsResponseDto.getId());
 
-    assertThat(getAuthorArticlesResponseDtoList.stream().anyMatch(getAuthorArticlesResponseDto ->
-        getAuthorArticlesResponseDto.getAuthorId().equals(authorId)));
+    assertTrue(getAuthorArticlesResponseDtoList.stream().anyMatch(getAuthorArticlesResponseDto ->
+        getAuthorArticlesResponseDto.getAuthorId().equals(authorDetailsResponseDto.getId())));
   }
 
   @Test
   public void getLatestArticles_LatestArticlesFetched_True() {
     List<GetLatestArticlesResponseDto> getLatestArticlesResponseDtoList = getArticleService.getLatestArticles();
 
-    assertThat(!getLatestArticlesResponseDtoList.isEmpty());
+    assertFalse(getLatestArticlesResponseDtoList.isEmpty());
   }
 
   @Test
   public void getPopularArticles_PopularArticlesFetched_True() {
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa10@mail.com");
+
+    List<GetAuthorArticlesResponseDto> getAuthorArticlesResponseDtoList = getArticleService.getArticlesByAuthor(authorDetailsResponseDto.getId());
+
+    GetAuthorArticlesResponseDto getAuthorArticlesResponseDto = getAuthorArticlesResponseDtoList.stream()
+        .filter(response -> response.getTitle().equals("New iPhone announced"))
+        .findAny()
+        .orElseThrow(() -> new IllegalStateException("Author article does not exists"));
+
+    for (int i = 0; i < 5; i++) {
+      updateArticleService.likeArticle(getAuthorArticlesResponseDto.getId());
+    }
+
     List<GetPopularArticlesResponseDto> getPopularArticlesResponseDtoList = getArticleService.getPopularArticles();
 
-    assertThat(!getPopularArticlesResponseDtoList.isEmpty());
+    assertFalse(getPopularArticlesResponseDtoList.isEmpty());
   }
 
   @Test
   public void getAll_AllArticlesFetched_True() {
     List<GetArticleDetailsResponseDto> getArticleDetailsResponseDtoList = getArticleService.getAll();
 
-    assertThat(!getArticleDetailsResponseDtoList.isEmpty());
+    assertFalse(getArticleDetailsResponseDtoList.isEmpty());
   }
 
 }

--- a/src/test/java/bootcamp/five/agency/newys/services/article/UpdateArticleServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/services/article/UpdateArticleServiceTest.java
@@ -1,67 +1,141 @@
 package bootcamp.five.agency.newys.services.article;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bootcamp.five.agency.newys.dto.response.article.GetArticleDetailsResponseDto;
+import bootcamp.five.agency.newys.dto.response.article.GetAuthorArticlesResponseDto;
+import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
+import bootcamp.five.agency.newys.services.author.CreateAuthorService;
+import bootcamp.five.agency.newys.services.author.GetAuthorService;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class UpdateArticleServiceTest {
 
+  @Autowired
+  private CreateAuthorService createAuthorService;
+  @Autowired
+  private GetAuthorService getAuthorService;
+  @Autowired
+  private CreateArticleService createArticleService;
   @Autowired
   private UpdateArticleService updateArticleService;
   @Autowired
   private GetArticleService getArticleService;
 
+  @BeforeAll
+  public void initAuthor() {
+    final String firstName = "Rocky";
+    final String lastName = "Balboa";
+    final String email = "rocky.balboa5@mail.com";
+    final String type = "sport";
+
+    createAuthorService.createAuthor(firstName, lastName, email, type);
+  }
+
+  @BeforeEach
+  public void initArticle() {
+    final String title = "New iPhone 11 announced";
+    final String description = "New iPhone 11 announced";
+    final String imageUrl = "images/iphone11.png";
+    final Date dateOfPublication = new Date();
+    final String content = "New iPhone 11 announced";
+
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa5@mail.com");
+
+    createArticleService.createArticle(title, description, imageUrl, dateOfPublication, content, authorDetailsResponseDto.getId());
+  }
+
   @Test
   public void updateArticle_ArticleUpdated_True() {
-    final Long id = 1L;
     final String title = "New Samsung announced";
     final String description = "New Samsung announced";
     final String imageUrl = "images/samsung.png";
     final String content = "New Samsung announced";
 
-    GetArticleDetailsResponseDto getArticleDetailsResponseDto = updateArticleService.updateArticle(id, title, description, imageUrl, content);
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa5@mail.com");
 
-    assertThat(getArticleDetailsResponseDto.getId().equals(id));
-    assertThat(getArticleDetailsResponseDto.getTitle().equals(title));
-    assertThat(getArticleDetailsResponseDto.getDescription().equals(description));
-    assertThat(getArticleDetailsResponseDto.getImageUrl().equals(imageUrl));
-    assertThat(getArticleDetailsResponseDto.getContent().equals(content));
+    List<GetAuthorArticlesResponseDto> getAuthorArticlesResponseDtoList = getArticleService.getArticlesByAuthor(authorDetailsResponseDto.getId());
+
+    GetAuthorArticlesResponseDto getAuthorArticlesResponseDto = getAuthorArticlesResponseDtoList.stream()
+        .filter(response -> response.getTitle().equals("New iPhone 11 announced"))
+        .findAny()
+        .orElseThrow(() -> new IllegalStateException("Author article does not exists"));
+
+    GetArticleDetailsResponseDto updatedGetArticleDetailsResponseDto = updateArticleService.updateArticle(getAuthorArticlesResponseDto.getId(), title,
+        description, imageUrl, content);
+
+    assertEquals(updatedGetArticleDetailsResponseDto.getId(), getAuthorArticlesResponseDto.getId());
+    assertEquals(updatedGetArticleDetailsResponseDto.getTitle(), title);
+    assertEquals(updatedGetArticleDetailsResponseDto.getDescription(), description);
+    assertEquals(updatedGetArticleDetailsResponseDto.getImageUrl(), imageUrl);
+    assertEquals(updatedGetArticleDetailsResponseDto.getContent(), content);
   }
 
   @Test
   public void changeArticleAuthor_ArticleAuthorChanged_True() {
-    final Long id = 1L;
-    final Long authorId = 2L;
+    final String firstName = "John";
+    final String lastName = "Doe";
+    final String email = "john.doe2@mail.com";
+    final String type = "tech";
 
-    GetArticleDetailsResponseDto getArticleDetailsResponseDto = updateArticleService.changeArticleAuthor(id, authorId);
+    AuthorDetailsResponseDto updateAuthorDetailsResponseDto = createAuthorService.createAuthor(firstName, lastName, email, type);
 
-    assertThat(getArticleDetailsResponseDto.getAuthorId().equals(authorId));
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa5@mail.com");
+
+    List<GetAuthorArticlesResponseDto> getAuthorArticlesResponseDtoList = getArticleService.getArticlesByAuthor(authorDetailsResponseDto.getId());
+
+    GetAuthorArticlesResponseDto getAuthorArticlesResponseDto = getAuthorArticlesResponseDtoList.stream()
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("Author article does not exists"));
+
+    GetArticleDetailsResponseDto updatedGetArticleDetailsResponseDto = updateArticleService.changeArticleAuthor(getAuthorArticlesResponseDto.getId(),
+        updateAuthorDetailsResponseDto.getId());
+
+    assertEquals(updatedGetArticleDetailsResponseDto.getAuthorId(), updateAuthorDetailsResponseDto.getId());
   }
 
   @Test
   public void likeArticle_ArticleLiked_True() {
-    final Long id = 1L;
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa5@mail.com");
 
-    GetArticleDetailsResponseDto getArticleDetailsResponseDto = getArticleService.getArticleById(id);
+    List<GetAuthorArticlesResponseDto> getAuthorArticlesResponseDtoList = getArticleService.getArticlesByAuthor(authorDetailsResponseDto.getId());
 
-    GetArticleDetailsResponseDto likedGetArticleDetailsResponseDto = updateArticleService.likeArticle(id);
+    GetAuthorArticlesResponseDto getAuthorArticlesResponseDto = getAuthorArticlesResponseDtoList.stream()
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("Author article does not exists"));
 
-    assertThat(getArticleDetailsResponseDto.getNumLikes() < likedGetArticleDetailsResponseDto.getNumLikes());
+    GetArticleDetailsResponseDto getArticleDetailsResponseDto = getArticleService.getArticleById(getAuthorArticlesResponseDto.getId());
+
+    GetArticleDetailsResponseDto likedGetArticleDetailsResponseDto = updateArticleService.likeArticle(getAuthorArticlesResponseDto.getId());
+
+    assertTrue(getArticleDetailsResponseDto.getNumLikes() < likedGetArticleDetailsResponseDto.getNumLikes());
   }
 
   @Test
   public void unlikeArticle_ArticleUnlike_True() {
-    final Long id = 1L;
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa5@mail.com");
 
-    GetArticleDetailsResponseDto getArticleDetailsResponseDto = getArticleService.getArticleById(id);
+    List<GetAuthorArticlesResponseDto> getAuthorArticlesResponseDtoList = getArticleService.getArticlesByAuthor(authorDetailsResponseDto.getId());
 
-    GetArticleDetailsResponseDto unlikedGetArticleDetailsResponseDto = updateArticleService.unlikeArticle(id);
+    GetAuthorArticlesResponseDto getAuthorArticlesResponseDto = getAuthorArticlesResponseDtoList.stream()
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("Author article does not exists"));
 
-    assertThat(getArticleDetailsResponseDto.getNumLikes() > unlikedGetArticleDetailsResponseDto.getNumLikes());
+    GetArticleDetailsResponseDto getArticleDetailsResponseDto = getArticleService.getArticleById(getAuthorArticlesResponseDto.getId());
+
+    GetArticleDetailsResponseDto unlikedGetArticleDetailsResponseDto = updateArticleService.unlikeArticle(getAuthorArticlesResponseDto.getId());
+
+    assertTrue(getArticleDetailsResponseDto.getNumLikes() > unlikedGetArticleDetailsResponseDto.getNumLikes());
   }
 
 }

--- a/src/test/java/bootcamp/five/agency/newys/services/author/CreateAuthorServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/services/author/CreateAuthorServiceTest.java
@@ -1,6 +1,7 @@
 package bootcamp.five.agency.newys.services.author;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
 import org.junit.jupiter.api.Test;
@@ -17,16 +18,16 @@ public class CreateAuthorServiceTest {
   public void createAuthor_AuthorCreated_True() {
     final String firstName = "Rocky";
     final String lastName = "Balboa";
-    final String email = "rocky.balboa@mail.com";
+    final String email = "rocky.balboa1@mail.com";
     final String type = "sport";
 
     AuthorDetailsResponseDto authorDetailsResponseDto = createAuthorService.createAuthor(firstName, lastName, email, type);
 
-    assertThat(authorDetailsResponseDto.getId() != null);
-    assertThat(authorDetailsResponseDto.getFirstName().equals(firstName));
-    assertThat(authorDetailsResponseDto.getLastName().equals(lastName));
-    assertThat(authorDetailsResponseDto.getEmail().equals(email));
-    assertThat(authorDetailsResponseDto.getType().equals(type));
+    assertNotNull(authorDetailsResponseDto.getId());
+    assertEquals(authorDetailsResponseDto.getFirstName(), firstName);
+    assertEquals(authorDetailsResponseDto.getLastName(), lastName);
+    assertEquals(authorDetailsResponseDto.getEmail(), email);
+    assertEquals(authorDetailsResponseDto.getType(), type);
   }
 
 }

--- a/src/test/java/bootcamp/five/agency/newys/services/author/DeleteAuthorServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/services/author/DeleteAuthorServiceTest.java
@@ -1,7 +1,9 @@
 package bootcamp.five.agency.newys.services.author;
 
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatException;
 
+import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -10,17 +12,29 @@ import org.springframework.boot.test.context.SpringBootTest;
 public class DeleteAuthorServiceTest {
 
   @Autowired
+  private CreateAuthorService createAuthorService;
+  @Autowired
   private DeleteAuthorService deleteAuthorService;
   @Autowired
   private GetAuthorService getAuthorService;
 
+  @BeforeEach
+  public void init() {
+    final String firstName = "Rocky";
+    final String lastName = "Balboa";
+    final String email = "rocky.balboa6@mail.com";
+    final String type = "sport";
+
+    createAuthorService.createAuthor(firstName, lastName, email, type);
+  }
+
   @Test
   public void deleteAuthor_AuthorDeleted_True() {
-    final Long id = 2L;
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa6@mail.com");
 
-    deleteAuthorService.deleteAuthorById(id);
+    deleteAuthorService.deleteAuthorById(authorDetailsResponseDto.getId());
 
-    assertThatIllegalStateException().isThrownBy(() -> getAuthorService.getAuthorById(id));
+    assertThatException().isThrownBy(() -> getAuthorService.getAuthorById(authorDetailsResponseDto.getId()));
   }
 
 }

--- a/src/test/java/bootcamp/five/agency/newys/services/author/GetAuthorServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/services/author/GetAuthorServiceTest.java
@@ -1,54 +1,71 @@
 package bootcamp.five.agency.newys.services.author;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
 import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class GetAuthorServiceTest {
 
   @Autowired
+  public CreateAuthorService createAuthorService;
+  @Autowired
   public GetAuthorService getAuthorService;
+
+  @BeforeAll
+  public void init() {
+    final String firstName = "Jane";
+    final String lastName = "Doe";
+    final String email = "jane.doe@mail.com";
+    final String type = "tech";
+
+    createAuthorService.createAuthor(firstName, lastName, email, type);
+  }
 
   @Test
   public void getAuthorById_AuthorFetched_True() {
-    final Long id = 1L;
+    AuthorDetailsResponseDto createAuthorDetailsResponseDto = getAuthorService.getAuthorByEmail("jane.doe@mail.com");
 
-    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorById(id);
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorById(createAuthorDetailsResponseDto.getId());
 
-    assertThat(authorDetailsResponseDto.getId().equals(id));
+    assertEquals(authorDetailsResponseDto.getId(), createAuthorDetailsResponseDto.getId());
   }
 
   @Test
   public void getAuthorByFirstNameAndLastName_AuthorFetched_True() {
-    final String firstName = "John";
+    final String firstName = "Jane";
     final String lastName = "Doe";
 
     AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByFirstNameAndLastName(firstName, lastName);
 
-    assertThat(authorDetailsResponseDto.getFirstName().equals(firstName));
-    assertThat(authorDetailsResponseDto.getLastName().equals(lastName));
+    assertEquals(authorDetailsResponseDto.getFirstName(), firstName);
+    assertEquals(authorDetailsResponseDto.getLastName(), lastName);
   }
 
   @Test
   public void getAuthorByEmail_AuthorFetched_True() {
-    final String email = "john.doe@mail.com";
+    final String email = "jane.doe@mail.com";
 
     AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail(email);
 
-    assertThat(authorDetailsResponseDto.getEmail().equals(email));
+    assertEquals(authorDetailsResponseDto.getEmail(), email);
   }
 
   @Test void getNumberOfArticles_NumberOfArticlesIsZero_True() {
-    final Long id = 1L;
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("jane.doe@mail.com");
 
-    Integer numberOfArticles = getAuthorService.getNumberOfArticles(id);
+    Integer numberOfArticles = getAuthorService.getNumberOfArticles(authorDetailsResponseDto.getId());
 
-    assertThat(numberOfArticles == 0);
+    assertEquals(numberOfArticles, 0);
   }
 
   @Test
@@ -57,15 +74,15 @@ public class GetAuthorServiceTest {
 
     List<AuthorDetailsResponseDto> authorDetailsResponseDtoList = getAuthorService.getByType(type);
 
-    assertThat(!authorDetailsResponseDtoList.isEmpty());
-    assertThat(authorDetailsResponseDtoList.stream().anyMatch(getAuthorDetailsResponseDto -> getAuthorDetailsResponseDto.getType().equals(type)));
+    assertFalse(authorDetailsResponseDtoList.isEmpty());
+    assertTrue(authorDetailsResponseDtoList.stream().anyMatch(getAuthorDetailsResponseDto -> getAuthorDetailsResponseDto.getType().equals(type)));
   }
 
   @Test
   public void getAll_AllAuthorsFetched_True() {
     List<AuthorDetailsResponseDto> authorDetailsResponseDtoList = getAuthorService.getAll();
 
-    assertThat(!authorDetailsResponseDtoList.isEmpty());
+    assertFalse(authorDetailsResponseDtoList.isEmpty());
   }
 
 }

--- a/src/test/java/bootcamp/five/agency/newys/services/author/UpdateAuthorServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/services/author/UpdateAuthorServiceTest.java
@@ -1,8 +1,9 @@
 package bootcamp.five.agency.newys.services.author;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -11,23 +12,39 @@ import org.springframework.boot.test.context.SpringBootTest;
 public class UpdateAuthorServiceTest {
 
   @Autowired
+  private CreateAuthorService createAuthorService;
+  @Autowired
+  private GetAuthorService getAuthorService;
+  @Autowired
   private UpdateAuthorService updateAuthorService;
+
+  @BeforeEach
+  public void init() {
+    final String firstName = "Rocky";
+    final String lastName = "Balboa";
+    final String email = "rocky.balboa4@mail.com";
+    final String type = "sport";
+
+    createAuthorService.createAuthor(firstName, lastName, email, type);
+  }
 
   @Test
   public void updateAuthor_AuthorUpdated_True() {
-    final Long id = 1L;
     final String firstName = "John";
     final String lastName = "Doe";
-    final String email = "john.doe@mail.com";
+    final String email = "john.doe1@mail.com";
     final String type = "tech";
 
-    AuthorDetailsResponseDto authorDetailsResponseDto = updateAuthorService.updateAuthor(id, firstName, lastName, email, type);
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa4@mail.com");
 
-    assertThat(authorDetailsResponseDto.getId().equals(id));
-    assertThat(authorDetailsResponseDto.getFirstName().equals(firstName));
-    assertThat(authorDetailsResponseDto.getLastName().equals(lastName));
-    assertThat(authorDetailsResponseDto.getEmail().equals(email));
-    assertThat(authorDetailsResponseDto.getType().equals(type));
+    AuthorDetailsResponseDto updatedAuthorDetailsResponseDto = updateAuthorService.updateAuthor(authorDetailsResponseDto.getId(), firstName,
+        lastName, email, type);
+
+    assertEquals(updatedAuthorDetailsResponseDto.getId(), authorDetailsResponseDto.getId());
+    assertEquals(updatedAuthorDetailsResponseDto.getFirstName(), firstName);
+    assertEquals(updatedAuthorDetailsResponseDto.getLastName(), lastName);
+    assertEquals(updatedAuthorDetailsResponseDto.getEmail(), email);
+    assertEquals(updatedAuthorDetailsResponseDto.getType(), type);
   }
 
 }

--- a/src/test/java/bootcamp/five/agency/newys/services/category/CreateCategoryServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/services/category/CreateCategoryServiceTest.java
@@ -1,8 +1,13 @@
 package bootcamp.five.agency.newys.services.category;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
 import bootcamp.five.agency.newys.dto.response.category.GetCategoryDetailsResponseDto;
+import bootcamp.five.agency.newys.services.author.CreateAuthorService;
+import bootcamp.five.agency.newys.services.author.GetAuthorService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -11,20 +16,36 @@ import org.springframework.boot.test.context.SpringBootTest;
 public class CreateCategoryServiceTest {
 
   @Autowired
+  private CreateAuthorService createAuthorService;
+  @Autowired
+  private GetAuthorService getAuthorService;
+  @Autowired
   private CreateCategoryService createCategoryService;
+
+  @BeforeEach
+  public void init() {
+    final String firstName = "Rocky";
+    final String lastName = "Balboa";
+    final String email = "rocky.balboa3@mail.com";
+    final String type = "sport";
+
+    createAuthorService.createAuthor(firstName, lastName, email, type);
+  }
 
   @Test
   public void createCategory_CategoryCreated_True() {
     final String name = "Sports";
     final String description = "Sports category";
-    final Long authorId = 1L;
 
-    GetCategoryDetailsResponseDto getCategoryDetailsResponseDto = createCategoryService.createCategory(name, description, authorId);
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa3@mail.com");
 
-    assertThat(getCategoryDetailsResponseDto.getId() != null);
-    assertThat(getCategoryDetailsResponseDto.getName().equals(name));
-    assertThat(getCategoryDetailsResponseDto.getDescription().equals(description));
-    assertThat(getCategoryDetailsResponseDto.getAuthorId().equals(authorId));
+    GetCategoryDetailsResponseDto getCategoryDetailsResponseDto = createCategoryService.createCategory(name, description,
+        authorDetailsResponseDto.getId());
+
+    assertNotNull(getCategoryDetailsResponseDto.getId());
+    assertEquals(getCategoryDetailsResponseDto.getName(), name);
+    assertEquals(getCategoryDetailsResponseDto.getDescription(), description);
+    assertEquals(getCategoryDetailsResponseDto.getAuthorId(), authorDetailsResponseDto.getId());
   }
 
 }

--- a/src/test/java/bootcamp/five/agency/newys/services/category/DeleteCategoryServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/services/category/DeleteCategoryServiceTest.java
@@ -1,7 +1,13 @@
 package bootcamp.five.agency.newys.services.category;
 
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatException;
 
+import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
+import bootcamp.five.agency.newys.dto.response.category.GetAuthorCategoriesResponseDto;
+import bootcamp.five.agency.newys.services.author.CreateAuthorService;
+import bootcamp.five.agency.newys.services.author.GetAuthorService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -10,17 +16,46 @@ import org.springframework.boot.test.context.SpringBootTest;
 public class DeleteCategoryServiceTest {
 
   @Autowired
+  private CreateAuthorService createAuthorService;
+  @Autowired
+  private GetAuthorService getAuthorService;
+  @Autowired
+  private CreateCategoryService createCategoryService;
+  @Autowired
   private DeleteCategoryService deleteCategoryService;
   @Autowired
   private GetCategoryService getCategoryService;
 
+  @BeforeEach
+  public void init() {
+    final String firstName = "Rocky";
+    final String lastName = "Balboa";
+    final String email = "rocky.balboa9@mail.com";
+    final String type = "sport";
+
+    AuthorDetailsResponseDto authorDetailsResponseDto = createAuthorService.createAuthor(firstName, lastName, email, type);
+
+    final String name = "Sports";
+    final String description = "Sports category";
+
+    createCategoryService.createCategory(name, description, authorDetailsResponseDto.getId());
+  }
+
   @Test
   public void deleteCategoryById_CategoryDeleted_True() {
-    final Long id = 1L;
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa9@mail.com");
 
-    deleteCategoryService.deleteCategoryById(id);
+    List<GetAuthorCategoriesResponseDto> getAuthorCategoriesResponseDtoList = getCategoryService.getCategoriesByAuthor(
+        authorDetailsResponseDto.getId());
 
-    assertThatIllegalStateException().isThrownBy(() -> getCategoryService.getCategoryById(id));
+    GetAuthorCategoriesResponseDto getAuthorCategoriesResponseDto = getAuthorCategoriesResponseDtoList.stream()
+        .filter(response -> response.getName().equals("Sports"))
+        .findAny()
+        .orElseThrow(() -> new IllegalStateException("Author category does not exists"));
+
+    deleteCategoryService.deleteCategoryById(getAuthorCategoriesResponseDto.getId());
+
+    assertThatException().isThrownBy(() -> getCategoryService.getCategoryById(getAuthorCategoriesResponseDto.getId()));
   }
 
 }

--- a/src/test/java/bootcamp/five/agency/newys/services/category/GetCategoryServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/services/category/GetCategoryServiceTest.java
@@ -1,44 +1,82 @@
 package bootcamp.five.agency.newys.services.category;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
 import bootcamp.five.agency.newys.dto.response.category.GetAuthorCategoriesResponseDto;
 import bootcamp.five.agency.newys.dto.response.category.GetCategoryDetailsResponseDto;
+import bootcamp.five.agency.newys.services.author.CreateAuthorService;
+import bootcamp.five.agency.newys.services.author.GetAuthorService;
 import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class GetCategoryServiceTest {
 
   @Autowired
+  private CreateAuthorService createAuthorService;
+  @Autowired
+  private GetAuthorService getAuthorService;
+  @Autowired
+  private CreateCategoryService createCategoryService;
+  @Autowired
   private GetCategoryService getCategoryService;
+
+  @BeforeAll
+  public void initAuthor() {
+    final String firstName = "Rocky";
+    final String lastName = "Balboa";
+    final String email = "rocky.balboa11@mail.com";
+    final String type = "sport";
+
+    AuthorDetailsResponseDto authorDetailsResponseDto = createAuthorService.createAuthor(firstName, lastName, email, type);
+
+    final String name = "Sports";
+    final String description = "Sports category";
+
+    createCategoryService.createCategory(name, description, authorDetailsResponseDto.getId());
+  }
 
   @Test
   public void getCategoryById_CategoryFetched_True() {
-    final Long id = 1L;
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa11@mail.com");
 
-    GetCategoryDetailsResponseDto getCategoryDetailsResponseDto = getCategoryService.getCategoryById(id);
+    List<GetAuthorCategoriesResponseDto> getAuthorCategoriesResponseDtoList = getCategoryService.getCategoriesByAuthor(
+        authorDetailsResponseDto.getId());
 
-    assertThat(getCategoryDetailsResponseDto.getId().equals(id));
+    GetAuthorCategoriesResponseDto getAuthorCategoriesResponseDto = getAuthorCategoriesResponseDtoList.stream()
+        .filter(response -> response.getName().equals("Sports"))
+        .findAny()
+        .orElseThrow(() -> new IllegalStateException("Author category does not exists"));
+
+    GetCategoryDetailsResponseDto getCategoryDetailsResponseDto = getCategoryService.getCategoryById(getAuthorCategoriesResponseDto.getId());
+
+    assertEquals(getCategoryDetailsResponseDto.getId(), getAuthorCategoriesResponseDto.getId());
   }
 
   @Test
   public void getCategoriesByAuthor_AuthorCategoriesFetched_True() {
-    final Long authorId = 2L;
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa11@mail.com");
 
-    List<GetAuthorCategoriesResponseDto> getAuthorCategoriesResponseDtoList = getCategoryService.getCategoriesByAuthor(authorId);
+    List<GetAuthorCategoriesResponseDto> getAuthorCategoriesResponseDtoList = getCategoryService.getCategoriesByAuthor(
+        authorDetailsResponseDto.getId());
 
-    assertThat(getAuthorCategoriesResponseDtoList.stream().anyMatch(getAuthorCategoriesResponseDto ->
-        getAuthorCategoriesResponseDto.getAuthorId().equals(authorId)));
+    assertTrue(getAuthorCategoriesResponseDtoList.stream().anyMatch(getAuthorCategoriesResponseDto ->
+        getAuthorCategoriesResponseDto.getAuthorId().equals(authorDetailsResponseDto.getId())));
   }
 
   @Test
   public void getAll_AllCategoriesFetched_True() {
     List<GetCategoryDetailsResponseDto> getCategoryDetailsResponseDtoList = getCategoryService.getAll();
 
-    assertThat(!getCategoryDetailsResponseDtoList.isEmpty());
+    assertFalse(getCategoryDetailsResponseDtoList.isEmpty());
   }
 
 }

--- a/src/test/java/bootcamp/five/agency/newys/services/category/UpdateCategoryServiceTest.java
+++ b/src/test/java/bootcamp/five/agency/newys/services/category/UpdateCategoryServiceTest.java
@@ -1,54 +1,136 @@
 package bootcamp.five.agency.newys.services.category;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import bootcamp.five.agency.newys.dto.response.article.GetArticleDetailsResponseDto;
 import bootcamp.five.agency.newys.dto.response.article.GetArticleInCategoryResponseDto;
+import bootcamp.five.agency.newys.dto.response.author.AuthorDetailsResponseDto;
+import bootcamp.five.agency.newys.dto.response.category.GetAuthorCategoriesResponseDto;
 import bootcamp.five.agency.newys.dto.response.category.GetCategoryDetailsResponseDto;
+import bootcamp.five.agency.newys.services.article.CreateArticleService;
+import bootcamp.five.agency.newys.services.author.CreateAuthorService;
+import bootcamp.five.agency.newys.services.author.GetAuthorService;
+import java.util.Date;
 import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class UpdateCategoryServiceTest {
 
+  @Autowired
+  private CreateAuthorService createAuthorService;
+  @Autowired
+  private GetAuthorService getAuthorService;
+  @Autowired
+  private CreateArticleService createArticleService;
+  @Autowired
+  private CreateCategoryService createCategoryService;
+  @Autowired
+  private GetCategoryService getCategoryService;
   @Autowired
   private UpdateCategoryService updateCategoryService;
   @Autowired
   private GetAddedArticlesService getAddedArticlesService;
 
+  @BeforeAll
+  public void initAuthor() {
+    final String firstName = "Rocky";
+    final String lastName = "Balboa";
+    final String email = "rocky.balboa7@mail.com";
+    final String type = "sport";
+
+    createAuthorService.createAuthor(firstName, lastName, email, type);
+  }
+
+  @BeforeEach
+  public void initCategory() {
+    final String name = "Sports";
+    final String description = "Sports category";
+
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa7@mail.com");
+
+    createCategoryService.createCategory(name, description, authorDetailsResponseDto.getId());
+  }
+
   @Test
   public void updateCategory_CategoryUpdated_True() {
-    final Long id = 1L;
     final String name = "Tech";
     final String description = "Tech category";
 
-    GetCategoryDetailsResponseDto getCategoryDetailsResponseDto = updateCategoryService.updateCategory(id, name, description);
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa7@mail.com");
 
-    assertThat(getCategoryDetailsResponseDto.getId().equals(id));
-    assertThat(getCategoryDetailsResponseDto.getName().equals(name));
-    assertThat(getCategoryDetailsResponseDto.getDescription().equals(description));
+    List<GetAuthorCategoriesResponseDto> getAuthorCategoriesResponseDtoList = getCategoryService.getCategoriesByAuthor(
+        authorDetailsResponseDto.getId());
+
+    GetAuthorCategoriesResponseDto getAuthorCategoriesResponseDto = getAuthorCategoriesResponseDtoList.stream()
+        .filter(response -> response.getName().equals("Sports"))
+        .findAny()
+        .orElseThrow(() -> new IllegalStateException("Author category does not exists"));
+
+    GetCategoryDetailsResponseDto getCategoryDetailsResponseDto = updateCategoryService.updateCategory(getAuthorCategoriesResponseDto.getId(), name,
+        description);
+
+    assertEquals(getCategoryDetailsResponseDto.getId(), getAuthorCategoriesResponseDto.getId());
+    assertEquals(getCategoryDetailsResponseDto.getName(), name);
+    assertEquals(getCategoryDetailsResponseDto.getDescription(), description);
   }
 
   @Test
   public void changeCategoryAuthor_AuthorCategoryUpdated_True() {
-    final Long id = 1L;
-    final Long authorId = 2L;
+    final String firstName = "John";
+    final String lastName = "Doe";
+    final String email = "john.doe3@mail.com";
+    final String type = "tech";
 
-    GetCategoryDetailsResponseDto getCategoryDetailsResponseDto = updateCategoryService.changeCategoryAuthor(id, authorId);
+    AuthorDetailsResponseDto updateAuthorDetailsResponseDto = createAuthorService.createAuthor(firstName, lastName, email, type);
 
-    assertThat(getCategoryDetailsResponseDto.getAuthorId().equals(authorId));
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa7@mail.com");
+
+    List<GetAuthorCategoriesResponseDto> getAuthorCategoriesResponseDtoList = getCategoryService.getCategoriesByAuthor(
+        authorDetailsResponseDto.getId());
+
+    GetAuthorCategoriesResponseDto getAuthorCategoriesResponseDto = getAuthorCategoriesResponseDtoList.stream()
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("Author category does not exists"));
+
+    GetCategoryDetailsResponseDto getCategoryDetailsResponseDto = updateCategoryService.changeCategoryAuthor(getAuthorCategoriesResponseDto.getId(),
+        updateAuthorDetailsResponseDto.getId());
+
+    assertEquals(getCategoryDetailsResponseDto.getAuthorId(), updateAuthorDetailsResponseDto.getId());
   }
 
   @Test
   public void addArticleToCategory_ArticleAddedToCategory_True() {
-    final Long id = 1L;
-    final Long articleId = 1L;
+    final String title = "New iPhone 12 announced";
+    final String description = "New iPhone 12 announced";
+    final String imageUrl = "images/iphone12.png";
+    final Date dateOfPublication = new Date();
+    final String content = "New iPhone 12 announced";
 
-    updateCategoryService.addArticleToCategory(id, articleId);
-    List<GetArticleInCategoryResponseDto> getArticleInCategoryResponseDtoList = getAddedArticlesService.getAddedArticles(id);
+    AuthorDetailsResponseDto authorDetailsResponseDto = getAuthorService.getAuthorByEmail("rocky.balboa7@mail.com");
 
-    assertThat(!getArticleInCategoryResponseDtoList.isEmpty());
+    GetArticleDetailsResponseDto getArticleDetailsResponseDto = createArticleService.createArticle(title, description, imageUrl, dateOfPublication,
+        content, authorDetailsResponseDto.getId());
+
+    List<GetAuthorCategoriesResponseDto> getAuthorCategoriesResponseDtoList = getCategoryService.getCategoriesByAuthor(
+        authorDetailsResponseDto.getId());
+
+    GetAuthorCategoriesResponseDto getAuthorCategoriesResponseDto = getAuthorCategoriesResponseDtoList.stream()
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("Author category does not exists"));
+
+    updateCategoryService.addArticleToCategory(getAuthorCategoriesResponseDto.getId(), getArticleDetailsResponseDto.getId());
+    List<GetArticleInCategoryResponseDto> getArticleInCategoryResponseDtoList = getAddedArticlesService.getAddedArticles(
+        getAuthorCategoriesResponseDto.getId());
+
+    assertFalse(getArticleInCategoryResponseDtoList.isEmpty());
   }
 
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,12 @@
+
+spring.datasource.url=jdbc:h2:mem:localdb
+#spring.datasource.url=jdbc:h2:file:/Users/vlatko/Workspace/bootcamp/java-bootcamp-demo/src/main/resources/data/demo;AUTO_SERVER=true
+spring.datasource.username=username
+spring.datasource.password=password
+spring.datasource.driver-class-name=org.h2.Driver
+
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.generate-ddl=true
+spring.jpa.hibernate.ddl-auto=create
+
+spring.h2.console.enabled=true


### PR DESCRIPTION
Fixed unit tests for business layer (they do not have to be started sequentially anymore)
Added .builder() method to ResponseDto and Entity objects
Removed constructors and Builder from RequestDto objects
Added application.properties to test/resources
Updated application.properties (it takes now env variables for DB properties)